### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Additionally, check out [Snaps](http://github.com/aleffert/snaps/), a Dials plug
 
 ## Setup
 
-Dials is an unusual project in that it has an iOS component and a desktop component. As such, you can use Cocoapods or Carthage to fetch and version it, but you'll have to perform some additional manual steps afterward.
+Dials is an unusual project in that it has an iOS component and a desktop component. As such, you can use CocoaPods or Carthage to fetch and version it, but you'll have to perform some additional manual steps afterward.
 
-### Fetch Using Cocoapods
+### Fetch Using CocoaPods
 
 Add the following to your ``Podfile``:
 ```


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
